### PR TITLE
Fix HA 0.108 material dark red theme sidebar background

### DIFF
--- a/material_dark_red.yaml
+++ b/material_dark_red.yaml
@@ -11,6 +11,7 @@ material_dark_red:
   primary-color: "#d32f2f"
   primary-text-color: "#cfcfcf"
   secondary-background-color: "#131313"
+  sidebar-background-color: "#272822"
   sidebar-text_-_background: "#333333"
   sidebar-icon-color: "var(--paper-item-icon-color)"
   paper-card-header-color: "var(--paper-item-icon-color)"


### PR DESCRIPTION
HA 0.108 causes the material dark red theme to show a white background on the sidebar, this change fixes it.

![bitmoji](https://sdk.bitmoji.com/render/panel/02649df6-45bf-4446-83d0-33e394fa0b05-5a650a02-9b93-4939-a19a-62efec914cc0-v1.png?transparent=1&palette=1&width=246)