### PR TITLE
sidebar-background-color missing for material red, fixing that.

### DIFF
--- a/dark_red.yaml
+++ b/dark_red.yaml
@@ -11,6 +11,7 @@ dark_red:
   primary-color: "#d32f2f"
   primary-text-color: "#cfcfcf"
   secondary-background-color: "#131313"
+  sidebar-background-color: "#333333"
   sidebar-text_-_background: "#62717b"
   paper-card-header-color: "var(--paper-item-icon-color)"
   paper-item-icon-active-color: "var(--primary-color)"


### PR DESCRIPTION
Not sure why it disappeared, but here it is again, in all its glory.

